### PR TITLE
Fix problems on PHPStan Level 0-4

### DIFF
--- a/admin/class-speedguard-admin.php
+++ b/admin/class-speedguard-admin.php
@@ -84,7 +84,7 @@ class Speedguard_Admin {
 			if (get_transient('speedguard-notice-activation')){
 
 			$args = array(
-				'post_type' => SpeedGuard_Admin::$cpt_name ,
+				'post_type' => Speedguard_Admin::$cpt_name ,
 				'post_status' => 'publish',
 				'posts_per_page'   => -1, 
 				'fields' =>'ids',
@@ -282,12 +282,12 @@ class Speedguard_Admin {
 		return $classes;
 	}
 	//Plugin Item in Admin Menu
-	function speedguard_admin_menu() {
-		$this->main_page = add_menu_page(__( 'SpeedGuard', 'speedguard' ), __( 'SpeedGuard', 'speedguard' ), 'manage_options', 'speedguard_tests', array( 'SpeedGuard_Tests', 'tests_page'),'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IURPQ1RZUEUgc3ZnIFs8IUVOVElUWSBuc19mbG93cyAiaHR0cDovL25zLmFkb2JlLmNvbS9GbG93cy8xLjAvIj5dPjxzdmcgdmVyc2lvbj0iMS4yIiBiYXNlUHJvZmlsZT0idGlueSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6YT0iaHR0cDovL25zLmFkb2JlLmNvbS9BZG9iZVNWR1ZpZXdlckV4dGVuc2lvbnMvMy4wLyIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI5MXB4IiBoZWlnaHQ9IjkxcHgiIHZpZXdCb3g9Ii0wLjUgLTAuNSA5MSA5MSIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGRlZnM+PC9kZWZzPjxwYXRoIGZpbGw9IiM4Mjg3OEMiIGQ9Ik04NS42NDYsNDAuNjQ1Yy0yLjQwNCwwLTQuMzU1LDEuOTUyLTQuMzU1LDQuMzU1YzAsMjAuMDEzLTE2LjI3NywzNi4yOS0zNi4yOSwzNi4yOUMyNC45ODgsODEuMjksOC43MDksNjUuMDEzLDguNzA5LDQ1QzguNzA5LDI0Ljk4OCwyNC45ODgsOC43MDksNDUsOC43MDljMi40MDQsMCw0LjM1NC0xLjk1MSw0LjM1NC00LjM1NFM0Ny40MDQsMCw0NSwwQzIwLjE4NywwLDAsMjAuMTg3LDAsNDVjMCwyNC44MTQsMjAuMTg3LDQ1LDQ1LDQ1YzI0LjgxNCwwLDQ1LTIwLjE4Niw0NS00NUM5MCw0Mi41OTcsODguMDQ5LDQwLjY0NSw4NS42NDYsNDAuNjQ1eiIvPjxwYXRoIGZpbGw9IiM4Mjg3OEMiIGQ9Ik00Ny4zMiwzMC42MjRjLTEuMjM2LDEuODA1LTEuOTIzLDMuODA5LTIuMzkzLDUuNjc1Yy00Ljc3NiwwLjA0MS04LjYzNywzLjkyLTguNjM3LDguNzAxYzAsNC44MDcsMy45MDIsOC43MSw4LjcwOSw4LjcxYzQuODA3LDAsOC43MS0zLjkwMyw4LjcxLTguNzFjMC0xLjE1OC0wLjIzOC0yLjI1OS0wLjY0OC0zLjI3MmMxLjU0My0xLjE0OSwzLjEyOC0yLjU1NSw0LjMyNC00LjM5NmMxLjI5MS0yLjA4MywxLjkyNS00LjgwOCwzLjA5NC03LjE3N2MxLjExOS0yLjM5OCwyLjI4NC00Ljc3MSwzLjIzNi03LjA3OGMxLjAwNi0yLjI3OSwxLjg3Ny00LjQ1LDIuNjMxLTYuMzA5YzEuNDg3LTMuNzI1LDIuMzYxLTYuMjg2LDIuMzYxLTYuMjg2YzAuMDY3LTAuMTk3LDAuMDMyLTAuNDI0LTAuMTE2LTAuNTkyYy0wLjIyMS0wLjI1LTAuNjAyLTAuMjczLTAuODQ4LTAuMDU2YzAsMC0yLjAyNiwxLjc5NC00Ljg5Nyw0LjYwMmMtMS40MjMsMS40MDgtMy4wOTIsMy4wNTItNC44MTEsNC44NTRjLTEuNzY3LDEuNzY5LTMuNTA0LDMuNzU3LTUuMjkxLDUuNzEzQzUxLjAxOSwyNi45OTQsNDguNzQ4LDI4LjYyNiw0Ny4zMiwzMC42MjR6Ii8+PC9zdmc+','81');
-    $this->tests_page_hook = add_submenu_page('speedguard_tests', __('Speed Tests','speedguard'), __('Speed Tests','speedguard'), 'manage_options', 'speedguard_tests' ); 
-    $this->settings_page_hook = add_submenu_page('speedguard_tests',  __( 'Settings', 'speedguard' ),  __( 'Settings', 'speedguard' ), 'manage_options', 'speedguard_settings',array( 'SpeedGuard_Settings', 'my_settings_page_function') );		
-	}   
-	//Plugin Admin Notices	
+	public function speedguard_admin_menu() {
+		add_menu_page(__( 'SpeedGuard', 'speedguard' ), __( 'SpeedGuard', 'speedguard' ), 'manage_options', 'speedguard_tests', array( 'SpeedGuard_Tests', 'tests_page'),'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IURPQ1RZUEUgc3ZnIFs8IUVOVElUWSBuc19mbG93cyAiaHR0cDovL25zLmFkb2JlLmNvbS9GbG93cy8xLjAvIj5dPjxzdmcgdmVyc2lvbj0iMS4yIiBiYXNlUHJvZmlsZT0idGlueSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6YT0iaHR0cDovL25zLmFkb2JlLmNvbS9BZG9iZVNWR1ZpZXdlckV4dGVuc2lvbnMvMy4wLyIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI5MXB4IiBoZWlnaHQ9IjkxcHgiIHZpZXdCb3g9Ii0wLjUgLTAuNSA5MSA5MSIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGRlZnM+PC9kZWZzPjxwYXRoIGZpbGw9IiM4Mjg3OEMiIGQ9Ik04NS42NDYsNDAuNjQ1Yy0yLjQwNCwwLTQuMzU1LDEuOTUyLTQuMzU1LDQuMzU1YzAsMjAuMDEzLTE2LjI3NywzNi4yOS0zNi4yOSwzNi4yOUMyNC45ODgsODEuMjksOC43MDksNjUuMDEzLDguNzA5LDQ1QzguNzA5LDI0Ljk4OCwyNC45ODgsOC43MDksNDUsOC43MDljMi40MDQsMCw0LjM1NC0xLjk1MSw0LjM1NC00LjM1NFM0Ny40MDQsMCw0NSwwQzIwLjE4NywwLDAsMjAuMTg3LDAsNDVjMCwyNC44MTQsMjAuMTg3LDQ1LDQ1LDQ1YzI0LjgxNCwwLDQ1LTIwLjE4Niw0NS00NUM5MCw0Mi41OTcsODguMDQ5LDQwLjY0NSw4NS42NDYsNDAuNjQ1eiIvPjxwYXRoIGZpbGw9IiM4Mjg3OEMiIGQ9Ik00Ny4zMiwzMC42MjRjLTEuMjM2LDEuODA1LTEuOTIzLDMuODA5LTIuMzkzLDUuNjc1Yy00Ljc3NiwwLjA0MS04LjYzNywzLjkyLTguNjM3LDguNzAxYzAsNC44MDcsMy45MDIsOC43MSw4LjcwOSw4LjcxYzQuODA3LDAsOC43MS0zLjkwMyw4LjcxLTguNzFjMC0xLjE1OC0wLjIzOC0yLjI1OS0wLjY0OC0zLjI3MmMxLjU0My0xLjE0OSwzLjEyOC0yLjU1NSw0LjMyNC00LjM5NmMxLjI5MS0yLjA4MywxLjkyNS00LjgwOCwzLjA5NC03LjE3N2MxLjExOS0yLjM5OCwyLjI4NC00Ljc3MSwzLjIzNi03LjA3OGMxLjAwNi0yLjI3OSwxLjg3Ny00LjQ1LDIuNjMxLTYuMzA5YzEuNDg3LTMuNzI1LDIuMzYxLTYuMjg2LDIuMzYxLTYuMjg2YzAuMDY3LTAuMTk3LDAuMDMyLTAuNDI0LTAuMTE2LTAuNTkyYy0wLjIyMS0wLjI1LTAuNjAyLTAuMjczLTAuODQ4LTAuMDU2YzAsMC0yLjAyNiwxLjc5NC00Ljg5Nyw0LjYwMmMtMS40MjMsMS40MDgtMy4wOTIsMy4wNTItNC44MTEsNC44NTRjLTEuNzY3LDEuNzY5LTMuNTA0LDMuNzU3LTUuMjkxLDUuNzEzQzUxLjAxOSwyNi45OTQsNDguNzQ4LDI4LjYyNiw0Ny4zMiwzMC42MjR6Ii8+PC9zdmc+','81');
+		add_submenu_page('speedguard_tests', __('Speed Tests','speedguard'), __('Speed Tests','speedguard'), 'manage_options', 'speedguard_tests' ); 
+		add_submenu_page('speedguard_tests',  __( 'Settings', 'speedguard' ),  __( 'Settings', 'speedguard' ), 'manage_options', 'speedguard_settings',array( 'SpeedGuard_Settings', 'my_settings_page_function') );
+	}
+	//Plugin Admin Notices
 	public static function set_notice( $message, $class) {  return "<div class='notice notice-$class is-dismissible'><p>$message</p></div>"; }
 	public static function show_admin_notices() {
 	$speedguard_average = Speedguard_Admin::get_this_plugin_option('speedguard_average' );	
@@ -302,7 +302,7 @@ class Speedguard_Admin {
 		
 		if ( ! empty( $_POST['speedguard'] ) && $_POST['speedguard'] == 'add_new_url' ) {
 			//var_dump($_POST);
-			$notices = SpeedGuard_Tests::import_data($_POST);
+			$notices = SpeedGuard_Tests::import_data();
 		}
 		//TODO show notice while tests are running
 		if ( ! empty( $_REQUEST['speedguard'] ) && $_REQUEST['speedguard'] == 'retest_load_time' ) {

--- a/admin/includes/class.notifications.php
+++ b/admin/includes/class.notifications.php
@@ -23,7 +23,7 @@ class SpeedGuard_Notifications{
 				$subject = sprintf(__('%1$s speed report [SpeedGuard]','speedguard'),$site_url);
 			}
 			$args = array(
-				'post_type' => SpeedGuard_Admin::$cpt_name ,
+				'post_type' => Speedguard_Admin::$cpt_name ,
 				'post_status' => 'publish',
 				'posts_per_page'   => -1, 
 				'fields' =>'ids',

--- a/admin/includes/class.settings.php
+++ b/admin/includes/class.settings.php
@@ -80,7 +80,7 @@ class SpeedGuard_Settings{
 			if ( 'load_time' == $meta_key && $meta_value != 'waiting' ) {
 				$args = array(
 				'no_found_rows' => true, 
-				'post_type' => SpeedGuard_Admin::$cpt_name,
+				'post_type' => Speedguard_Admin::$cpt_name,
 				'post_status' => 'publish',
 				'posts_per_page'   => -1, 
 				'fields' =>'ids',
@@ -96,7 +96,7 @@ class SpeedGuard_Settings{
 				$waiting_tests = $the_query->get_posts();
 					if (count($waiting_tests) == 0){					
 						$args = array(
-							'post_type' => SpeedGuard_Admin::$cpt_name,
+							'post_type' => Speedguard_Admin::$cpt_name,
 							'post_status' => 'publish',
 							'posts_per_page'   => -1, 
 							'fields' =>'ids'
@@ -130,7 +130,7 @@ class SpeedGuard_Settings{
 												'guarded_pages_count' => 0							
 												);
 							}
-						if ($new_averages) Speedguard_Admin::update_this_plugin_option('speedguard_average', $new_averages);						
+						Speedguard_Admin::update_this_plugin_option('speedguard_average', $new_averages);						
 						wp_reset_postdata();
 					}
 				wp_reset_postdata();

--- a/admin/includes/class.widgets.php
+++ b/admin/includes/class.widgets.php
@@ -13,7 +13,7 @@ class SpeedGuardWidgets{
 	}
 
 	function speedguard_admin_bar_widget($wp_admin_bar ) { 
-		if (is_singular(SpeedGuard_Admin::supported_post_types())) {
+		if (is_singular(Speedguard_Admin::supported_post_types())) {
 			$type = 'single';
 		}
 		else if (is_archive()) {


### PR DESCRIPTION
Hello @sabrina-zeidan!

Please consider using @phpstan

`phpstan.neon.dist`

```yaml
includes:
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: max
    inferPrivatePropertyTypeFromConstructor: true
#    bootstrapFiles:
#        - tests/phpstan/bootstrap.php
    scanFiles:
        - ./includes/class-speedguard-deactivator.php
        - ./includes/class-speedguard-activator.php
        - ./includes/class-speedguard-i18n.php
        - ./includes/class-speedguard.php
        - ./includes/class-speedguard-loader.php
        - ./public/partials/speedguard-public-display.php
        - ./public/class-speedguard-public.php
        - ./uninstall.php
        - ./admin/partials/speedguard-admin-display.php
        - ./admin/class-speedguard-admin.php
        - ./admin/includes/class.tests.php
        - ./admin/includes/class.settings.php
        - ./admin/includes/class.widgets.php
        - ./admin/includes/class.notifications.php
        - ./admin/includes/class.lighthouse.php
        - ./speedguard.php
    paths:
        - speedguard.php
        - uninstall.php
        - includes/
        - admin/
        - public/
```
