### PR TITLE
Fix i18n titles and brand name

### DIFF
--- a/admin/class-speedguard-admin.php
+++ b/admin/class-speedguard-admin.php
@@ -323,7 +323,7 @@ class SpeedGuard_Admin {
 
 		} elseif ( self::is_screen( 'settings' ) ) {
 			if ( ! empty( $_REQUEST['settings-updated'] ) && $_REQUEST['settings-updated'] === 'true' ) {
-				$notices[] = self::set_notice( __( 'Settings have been updated!' ), 'success' );
+				$notices[] = self::set_notice( __( 'Settings have been updated!', 'speedguard' ), 'success' );
 			}
 		}
 

--- a/admin/includes/class.tests-table.php
+++ b/admin/includes/class.tests-table.php
@@ -619,7 +619,7 @@ class SpeedGuard_Tests {
 			SpeedGuard_Widgets::add_meta_boxes();
 			?>
             <div class="wrap">
-                <h2><?php esc_html_e( 'Speedguard :: Guarded pages', 'speedguard' ); ?></h2>
+                <h2><?php esc_html_e( 'SpeedGuard :: Guarded pages', 'speedguard' ); ?></h2>
                 <div id="poststuff" class="metabox-holder has-right-sidebar">
                     <div id="side-info-column" class="inner-sidebar">
 						<?php

--- a/admin/includes/class.widgets.php
+++ b/admin/includes/class.widgets.php
@@ -458,9 +458,9 @@ echo wp_kses_post( __( 'If there is no CWV data available -- you CAN use PSI as 
 	function speedguard_dashboard_widget_function() {
 		$sg_test_type = SpeedGuard_Settings::global_test_type();
 		if ( 'cwv' === $sg_test_type ) {
-			$origin_widget_title = 'Core Web Vitals for Origin';
+			$origin_widget_title = __( 'Core Web Vitals for Origin', 'speedguard' );
 		} elseif ( 'psi' === $sg_test_type ) {
-			$origin_widget_title = 'PageSpeed Insights Average';
+			$origin_widget_title = __( 'PageSpeed Insights Average', 'speedguard' );
 		}
 
 		wp_add_dashboard_widget( 'speedguard_dashboard_widget', __( $origin_widget_title . _( ' [SpeedGuard]' ), 'speedguard' ), [

--- a/admin/includes/class.widgets.php
+++ b/admin/includes/class.widgets.php
@@ -30,9 +30,9 @@ class SpeedGuard_Widgets {
 		], '', 'normal', 'core' );
 
 		if ( 'cwv' === $sg_test_type ) {
-			$origin_widget_title = 'Core Web Vitals for Origin -- real users\' experience for the entire website';
+			$origin_widget_title = __( 'Core Web Vitals for Origin -- real users\' experience for the entire website', 'speedguard' );
 		} elseif ( 'psi' === $sg_test_type ) {
-			$origin_widget_title = 'PageSpeed Insights (lab tests)';
+			$origin_widget_title = __( 'PageSpeed Insights (lab tests)', 'speedguard' );
 		}
 
 		add_meta_box( 'speedguard-dashboard-widget', esc_html__( $origin_widget_title, 'speedguard' ), [


### PR DESCRIPTION
Hi Sabrina :)

Thanks for the awesome plugin!

In this PR I fix:
- [x] Ttitles that aren't currently wrapped in gettext for i18n
- [x] String with the plugin brand name
- [x] Missing textdomain

I've just fixed things that I saw showing in the UI, despite many others that exist in the codebase, that you probably want to keep for debugging, untranslatable.